### PR TITLE
Add the macros folder to the repo, but ignore all the files inside of it

### DIFF
--- a/macros/.gitignore
+++ b/macros/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This is a special .gitignore file that tells the repository to ignore all the files in the macros folder but allows us to keep the folder.