### PR TITLE
Change the format for registering instrument functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# vim
+*.un~

--- a/Instruments/devClass_DDG.py
+++ b/Instruments/devClass_DDG.py
@@ -8,19 +8,10 @@ class DDGClass(devGlobal):
     def __init__(self, *args):
         devGlobal.__init__(self, *args)
 
-        self.label_list = self.label_list + [
-            ('Set Delay\nChX-ChY', self.SetDelayChCh, ""),
-            ('Set Output\nAmplitude', self.SetAmpCh, "Voltage Division"),  # 1
-            ('Set Trigger\nLevel', self.SetTriggerLvl, "Trigger Level")
-        ]
+        self.register(self.SetDelayChCh, 'Set Delay\nChX-ChY')
+        self.register(self.SetAmpCh, 'Set Output\nAmplitude', parameters = ["Voltage Division"])
+        self.register(self.SetTriggerLvl, 'Set Trigger\nLevel', parameters = ["Trigger Level"])
 
-        # Theoretical api instead of using label list above
-        # self.register(self.RunStop, 'Run\nStop')
-        # self.register(self.SetVoltDiv, 'Set Voltage\nDivision (V)', name = "Voltage Division", sc = True, dc = False, parameter = True)
-        # self.register(self.SetVoltDiv, 'Set Time\nDivision (μs)', name = "Time Division", parameter = True)
-
-        for label, function, *_ in self.label_list:
-            pub.subscribe(function, self.createTopic(label))
 
     def SetDelayChCh(self, event):
         param = self.GetParamVector()

--- a/Instruments/devClass_Scope.py
+++ b/Instruments/devClass_Scope.py
@@ -11,34 +11,13 @@ class ScopeClass(devGlobal):
         self.runStop = 0
         self.write(":STOP")
 
-        self.label_list = self.label_list + [
-                           ('Run\nStop',                 self.RunStop,       ""                ),
-                           ('Set Voltage\nDivision (V)', self.SetVoltDiv,    "Voltage Division"),  #1
-                           ('Set Time\nDivision (μs)',   self.SetTimeDiv,    "Time Division"   ),  #2
-                           ('Set Trigger\nLevel',        self.SetTriggerLvl, "Trigger Level"   ),  #3
-                           ('Measure\nFrequency',        self.MeasFreq,      ""                ),  #4
-                           ('Measure\nVpp',              self.MeasVpp,       ""                ),   #5
-                           ('Measure\nVpp', self.MeasVpp, ""),  # 5
-                           ('Measure\nVpp', self.MeasVpp, ""),  # 5
-                           ('Measure\nVpp', self.MeasVpp, ""),  # 5
-                           ('Measure\nVpp', self.MeasVpp, ""),  # 5
-                           ('Measure\nVpp', self.MeasVpp, ""),  # 5
-                           ('Measure\nVpp', self.MeasVpp, ""),  # 5
-                           ('Measure\nVpp', self.MeasVpp, ""),  # 5
-                           ('Measure\nVpp', self.MeasVpp, ""),  # 5
-                           ('Measure\nVpp', self.MeasVpp, ""),  # 5
-                           ('Measure\nVpp', self.MeasVpp, ""),  # 5
-                           ('Measure\nVpp', self.MeasVpp, ""),  # 5
-                           ('Test', self.RunStop, "")  # 5
-                           ]
-                           
-        # Theoretical api instead of using label list above
-        # self.register(self.RunStop, 'Run\nStop')
-        # self.register(self.SetVoltDiv, 'Set Voltage\nDivision (V)', name = "Voltage Division", sc = True, dc = False, parameter = True)
-        # self.register(self.SetVoltDiv, 'Set Time\nDivision (μs)', name = "Time Division", parameter = True)
-
-        for label, function, *_ in self.label_list:
-            pub.subscribe(function, self.createTopic(label))
+        # Register functions for use in the interface
+        self.register(self.RunStop, 'Run\nStop')
+        self.register(self.SetVoltDiv, 'Set Voltage\nDivision (V)', parameters = ["Voltage Division"])
+        self.register(self.SetTimeDiv, 'Set Time\nDivision (μs)', parameters = ["Time Division"])
+        self.register(self.SetTriggerLvl, 'Set Trigger\nLevel', parameters = ["Trigger Level"])
+        self.register(self.MeasFreq, 'Measure\nFrequency')
+        self.register(self.MeasVpp, 'Measure\nVpp')
 
     def RunStop(self, msg):
         if self.runStop == 0:

--- a/Instruments/devClass_SuperFast.py
+++ b/Instruments/devClass_SuperFast.py
@@ -72,28 +72,21 @@ class SuperFastClass(devGlobal):
 
         self.additionalPanels  = [(graphPanel, 'Graph Tab')]
 
-        self.label_list = self.label_list + [
-                           ('Gets Model\nOption',             self.GetModelOption,        ""),
-                           ('Segment\nLength',                self.SegmentLength,         ""),
-                           ('Tests',                          self.Tests,                 ""),
-                           ('Sets Operating\nChannel',        self.SetOperatingChannel,   ""),
-                           ('Standard\nSquare Wave',          self.SetStandardSquareWave, ""),
-                           ('Sets Operating\nChannel On/Off', self.OutputOnOff,           ""),
-                           ('Deletes\nAll Traces',            self.DeleteAllTraces,       ""),
-                           ('Queries\nTrace Points',          self.TracePoints,           ""),
-                           ('Ch1 Output\nOn/Off',             self.Ch1OnOff,              ""),  # 1
-                           ('Ch2 Output\nOn/Off',             self.Ch2OnOff,              ""),  # 2
-                           ('Sync\nCh1 and Ch2',              self.SyncChannels,          ""),  # 3
-                           ('Ch1 Trigger\nInt/Ext',           self.Ch1TrigIntExt,         ""),  # 4
-                           ('Ch2 Trigger\nInt/Ext',           self.Ch2TrigIntExt,         ""),  # 5
-                           ('Ch1 Set\nWait Time',             self.Ch1setWaitTime,        ""),  # 6
-                           ('Ch1 Set\nWait Time',             self.Ch1setWaitTime,        ""),  # 6
-                           ('Ch1 Set\nWait Time',             self.Ch1setWaitTime,        ""),  # 6
-                           ('Ch1 Set\nWait Time',             self.Ch1setWaitTime,        "")   # 6
-                           ]
+        self.register(self.GetModelOption,        'Gets Model\nOption')
+        self.register(self.SegmentLength,         'Segment\nLength')
+        self.register(self.Tests,                 'Tests')
+        self.register(self.SetOperatingChannel,   'Sets Operating\nChannel') # not this function used channel input, but we don't handle that yet
+        self.register(self.SetStandardSquareWave, 'Standard\nSquare Wave', parameters = ["Frequency"])
+        self.register(self.OutputOnOff,           'Sets Operating\nChannel On/Off',  "")
+        self.register(self.DeleteAllTraces,       'Deletes\nAll Traces')
+        self.register(self.TracePoints,           'Queries\nTrace Points')
+        self.register(self.Ch1OnOff,              'Ch1 Output\nOn/Off')
+        self.register(self.Ch2OnOff,              'Ch2 Output\nOn/Off')
+        self.register(self.SyncChannels,          'Sync\nCh1 and Ch2')
+        self.register(self.Ch1TrigIntExt,         'Ch1 Trigger\nInt/Ext', parameters = ["Ch1 Trigger"])
+        self.register(self.Ch2TrigIntExt,         'Ch2 Trigger\nInt/Ext', parameters = ["Ch1 Trigger"])
+        self.register(self.Ch1setWaitTime,        'Ch1 Set\nWait Time', parameters = ["CH1 Wait Time"])
 
-        for label, function, *_ in self.label_list:
-            pub.subscribe(function, self.createTopic(label))
 
     def GetModelOption(self, msg):
         cmdString   = "Queries memory option on "

--- a/Instruments/devGlobalFunctions.py
+++ b/Instruments/devGlobalFunctions.py
@@ -36,8 +36,14 @@ class devGlobal():
             param.append(self.paramVec[i].GetValue())
         return param
         
-    def register(self, func, label, name = "", sc = False, dc = False, parameter = False):
-        self.label_list.append((label, func, name, sc, dc, parameter))
+    def register(self, func, label, parameters = []):
+        # This needs to be changed, further down the road the inputs on each function 
+        # Need to be each given a name (currently we just have channel 1, channel 2,
+        # and parameter, the parameters list will hold those names
+        name = ""
+        if len(parameters) > 0:
+            name = parameters[0]
+        self.label_list.append((label, func, name, parameters))
         pub.subscribe(func, self.createTopic(label))
 
     def createTopic(self, label):

--- a/README.md
+++ b/README.md
@@ -8,4 +8,12 @@ The requirements can be installed with pip using
 
 note: I used the [pipreqs tool](https://github.com/bndr/pipreqs) to generate the requirements file
 
-## Adding new devices
+You will also be required to install the NI Visa software available for free on their website
+Additionally you will need libusb, information can be found on [the libusb website](https://libusb.info)
+
+## Adding functions to devices
+When adding a new function remember to register it inside the instruments ```__init__```. Below is an example
+```python
+self.register(self.SetStandardSquareWave, 'Standard\nSquare Wave', parameters = ["Frequency"])
+```
+This registers a function ```SetStandardSquareWave``` with the label ```Standard\nSquare Wave``` and specifies that it takes one parameter "Frequency". Currently a function can only have 1 parameter but eventually we'd like to support commands that accept an arbitrary number and the list format here lays the foundation for that.


### PR DESCRIPTION
From now on the label_list format is deprecated and we must use self.register
The README is updated to reflect this

I only applied these changes to the 3 instruments that were actually set up to work. When we go ahead and start adding new instruments we should use this format.

Let me know what you think!